### PR TITLE
fix the Azure OpenAI Service endpoint url error.

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -80,7 +80,7 @@ Requires [Raycast Pro](https://www.raycast.com/pro) to support.
 
 ### Azure OpenAI Service
 
-- API Entrypoint:`https://${resourceName}.openai.azure.com/openai/deployments/${deployName}/completions?api-version=${apiVersion}`
+- API Entrypoint:`https://${resourceName}.openai.azure.com/openai/deployments/${deployName}/chat/completions?api-version=${apiVersion}`
 - API Key: [Azure](https://portal.azure.com/) -> Azure OpenAI -> Keys and Endpoint
 - API Model：No configuration required.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ npm install && npm run dev
 
 ### Azure OpenAI Service
 
-- API Entrypoint：`https://${resourceName}.openai.azure.com/openai/deployments/${deployName}/completions?api-version=${apiVersion}`
+- API Entrypoint：`https://${resourceName}.openai.azure.com/openai/deployments/${deployName}/chat/completions?api-version=${apiVersion}`
 - API Key: [Azure](https://portal.azure.com/) -> Azure OpenAI -> Keys and Endpoint
 - API Model: 无需配置
 


### PR DESCRIPTION
Azure OpenAI Service
API Entrypoint：https://${resourceName}.openai.azure.com/openai/deployments/${deployName}/completions?api-version=${apiVersion}
should be:
https://${resourceName}.openai.azure.com/openai/deployments/${deployName}/**chat/**completions?api-version=${apiVersion}