### PR TITLE
feat: add custom model support for OpenAI provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -286,8 +286,20 @@
         {
           "value": "gpt-4-32k-0314",
           "title": "gpt-4-32k-0314"
+        },
+        {
+          "value": "custom",
+          "title": "custom"
         }
       ]
+    },
+    {
+      "name": "customModel",
+      "type": "textfield",
+      "required": false,
+      "title": "Custom Model",
+      "description": "Custom Model ID, which is only available when using the OpenAI provider and the API Model is set to custom",
+      "default": "gpt-3.5-turbo"
     },
     {
       "name": "toLang",

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -22,6 +22,7 @@ export function getProvider(provider: string): Provider {
       entrypoint: string;
       apikey: string;
       apiModel: string;
+      customModel: string;
     }>();
     const providerClass = PROVIDER_CLASSES[provider];
     record[provider] = new providerClass(preferences);

--- a/src/providers/openai/index.ts
+++ b/src/providers/openai/index.ts
@@ -11,9 +11,19 @@ export default class extends Provider {
   protected entrypoint: string;
   protected apikey: string; //
 
-  constructor({ apiModel, entrypoint, apikey }: { apiModel: string; entrypoint: string; apikey: string }) {
+  constructor({
+    apiModel,
+    entrypoint,
+    apikey,
+    customModel,
+  }: {
+    apiModel: string;
+    entrypoint: string;
+    apikey: string;
+    customModel: string;
+  }) {
     super();
-    this.model = apiModel;
+    this.model = apiModel === "custom" ? customModel : apiModel;
     this.entrypoint = entrypoint;
     this.apikey = apikey;
   }


### PR DESCRIPTION
For any API that is compatible with [OpenAI’s standard chat API](https://platform.openai.com/docs/api-reference/chat), you can set a custom field to specify the model you wish to use.

I also want to address an error that occurs when a custom model is not specified, but I do not have much time available to walk through the codebase. Do you have any advice on how to most efficiently handle this issue?